### PR TITLE
Revamp GitHub profile README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 [![Website](https://img.shields.io/badge/Website-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white)](https://nomadicmehul.dev/)
 
 ![Profile Views](https://komarev.com/ghpvc/?username=nomadicmehul&style=for-the-badge&color=blueviolet&label=PROFILE+VIEWS)
-[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fnomadicmehul.dev&count_bg=%236B5CE7&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=WEBSITE+VISITS&edge_flat=true)](https://nomadicmehul.dev/)
+![Website Visits](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhits.dwyl.com%2Fnomadicmehul%2Fnomadicmehul.dev.json&query=%24.count&label=WEBSITE+VISITS&style=for-the-badge&color=blueviolet)
 
 </div>
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,8 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 - 🦊 **Ex Mozilla Reps Council Member**
 - 🎙️ Podcast Host — [TACOS with Mehul](https://www.youtube.com/playlist?list=PL7m7kHJFCVjXKK9jeyWwroPYsvNUaPqCH)
 - 🌐 Founder — [CloudCaptain](https://github.com/nomadicmehul/CloudCaptain) & [Open Source Weekend](https://twitter.com/OSWeekend)
-- 🏙️ Community Organizer — [GDG Cloud Gandhinagar](https://gdg.community.dev/gdg-cloud-gandhinagar/) · [CNCF Cloud Native Gandhinagar](https://community.cncf.io/cloud-native-gandhinagar/) · [HashiCorp UG Gandhinagar](https://www.meetup.com/gandhinagar-hashicorp-user-group/)
+- 🏙️ Community Organizer — [Grafana and Friends Berlin](https://www.meetup.com/grafana-and-friends-berlin/)
+- 🏙️ Ex Community Organizer — [GDG Cloud Gandhinagar](https://gdg.community.dev/gdg-cloud-gandhinagar/) · [CNCF Cloud Native Gandhinagar](https://community.cncf.io/cloud-native-gandhinagar/) · [HashiCorp UG Gandhinagar](https://www.meetup.com/gandhinagar-hashicorp-user-group/)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@
 
 ## 🚀 About Me
 
-<img align="right" alt="Mehul Patel" src="https://camo.githubusercontent.com/f1ba0d26a1c7cdabebe6aefb07535f0e723ebb9e39dadb010bbdb2839331fa61/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f386b6c4d426e726e64366d7273574d4c31302f67697068792e676966" width="280" />
+<img align="right" alt="Mehul Patel" src="https://camo.githubusercontent.com/f1ba0d26a1c7cdabebe6aefb07535f0e723ebb9e39dadb010bbdb2839331fa61/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f386b6c4d426e726e64366d7273574d4c31302f67697068792e676966" width="360" />
 
 I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ technical sessions** delivered across **25+ countries**, impacting **50,000+ developers**. I specialize in cloud-native infrastructure, containerization, and AI-powered DevOps workflows.
 

--- a/readme.md
+++ b/readme.md
@@ -108,14 +108,6 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 
 ---
 
-## 📊 GitHub Stats
-
-<div align="center">
-  <img src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=nomadicmehul&theme=nord_dark" alt="GitHub Profile Details" width="720" />
-</div>
-
----
-
 <div align="center">
 
 ### 💬 Let's Connect

--- a/readme.md
+++ b/readme.md
@@ -111,10 +111,9 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 ## 📊 GitHub Stats
 
 <div align="center">
-  <img src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=nomadicmehul&theme=nord_dark" alt="GitHub Stats" height="180" />
-  <img src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=nomadicmehul&theme=nord_dark" alt="Top Languages" height="180" />
-  <br/>
-  <img src="https://github-readme-streak-stats.herokuapp.com?user=nomadicmehul&theme=dark&hide_border=true&ring=bb2acf&fire=bb2acf&currStreakLabel=ffffff" alt="GitHub Streak" height="180" />
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=nomadicmehul&theme=nord_dark" alt="GitHub Stats" height="140" />
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=nomadicmehul&theme=nord_dark" alt="Top Languages" height="140" />
+  <img src="https://github-readme-streak-stats.herokuapp.com?user=nomadicmehul&theme=dark&hide_border=true&ring=bb2acf&fire=bb2acf&currStreakLabel=ffffff" alt="GitHub Streak" height="140" />
 </div>
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,8 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 
 ![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=prometheus&logoColor=white)
 ![Grafana](https://img.shields.io/badge/Grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white)
-![Datadog](https://img.shields.io/badge/Datadog-632CA6?style=for-the-badge&logo=datadog&logoColor=white)
+![Nagios](https://img.shields.io/badge/Nagios-999999?style=for-the-badge&logo=nagios&logoColor=white)
+![Zabbix](https://img.shields.io/badge/Zabbix-D40000?style=for-the-badge&logo=zabbix&logoColor=white)
 
 **Dev & Automation**
 

--- a/readme.md
+++ b/readme.md
@@ -3,32 +3,46 @@
 # Hey, I'm Mehul Patel 👋
 ### Senior DevOps Engineer · Docker Captain 🐳 · Google Developer Expert ☁️ · AWS Community Builder 🛠️
 
-*Bridging the gap between traditional infrastructure and the AI-powered cloud-native future.*
+*Building cloud-native by day, building communities by night — across 25+ countries and counting.*
 
 [![Twitter](https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white)](https://twitter.com/nomadicmehul)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/nomadicmehul/)
 [![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/c/NomadicMehul)
 [![Medium](https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white)](https://medium.com/@nomadicmehul)
-[![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/nomadicmehul)
+[![Instagram](https://img.shields.io/badge/Instagram-E4405F?style=for-the-badge&logo=instagram&logoColor=white)](https://instagram.com/nomadicmehul)
+[![Website](https://img.shields.io/badge/Website-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white)](https://nomadicmehul.dev/)
+
+![Profile Views](https://komarev.com/ghpvc/?username=nomadicmehul&style=for-the-badge&color=blueviolet&label=PROFILE+VIEWS)
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fnomadicmehul.dev&count_bg=%236B5CE7&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=WEBSITE+VISITS&edge_flat=true)](https://nomadicmehul.dev/)
 
 </div>
 
 ---
 
-<img align="right" alt="Coding GIF" src="https://camo.githubusercontent.com/f1ba0d26a1c7cdabebe6aefb07535f0e723ebb9e39dadb010bbdb2839331fa61/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f386b6c4d426e726e64366d7273574d4c31302f67697068792e676966" width="340" />
-
 ## 🚀 About Me
 
-I'm a **Senior DevOps Engineer** based in Berlin with **500+ technical sessions** delivered across **25+ countries**. I specialize in cloud-native infrastructure, containerization and AI-powered DevOps workflows and I love turning complex systems into compelling stories on stage and in code.
+I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ technical sessions** delivered across **25+ countries**, impacting **50,000+ developers**. I specialize in cloud-native infrastructure, containerization, and AI-powered DevOps workflows.
 
 - 🐳 **Docker Captain** — one of ~150 globally recognized Docker experts
 - ☁️ **Google Developer Expert** — Google Cloud
-- 🛠️ **AWS Community Builder**
+- 🛠️ **AWS Community Builder** — Cloud Architecture & DevOps
+- 🔐 **Auth0 Ambassador** — Auth0 by Okta
+- 🦊 **Mozilla Reps Council Member**
 - 🎙️ Podcast Host — [TACOS with Mehul](https://www.youtube.com/playlist?list=PL7m7kHJFCVjXKK9jeyWwroPYsvNUaPqCH)
 - 🌐 Founder — [CloudCaptain](https://github.com/nomadicmehul/CloudCaptain) & [Open Source Weekend](https://twitter.com/OSWeekend)
 - 🏙️ Community Organizer — [GDG Cloud Gandhinagar](https://gdg.community.dev/gdg-cloud-gandhinagar/) · [CNCF Cloud Native Gandhinagar](https://community.cncf.io/cloud-native-gandhinagar/) · [HashiCorp UG Gandhinagar](https://www.meetup.com/gandhinagar-hashicorp-user-group/)
 
-> *"From Docker containers to Vertex AI — I help teams ship faster, safer and smarter."*
+---
+
+## 📈 Community Impact
+
+<div align="center">
+
+| 🎤 500+ Sessions | 🌍 25+ Countries | 👥 50,000+ Developers | 🧑‍🏫 305+ Mentored (4.9/5) |
+|:-:|:-:|:-:|:-:|
+| **100+ Conferences** | **1,000+ Workshop Hours** | **Master's in CS** | **Fluent: EN · HI · GU** |
+
+</div>
 
 ---
 
@@ -36,9 +50,11 @@ I'm a **Senior DevOps Engineer** based in Berlin with **500+ technical sessions*
 
 | Project | Description |
 |---|---|
-| 🤖 [**AI-Powered SRE Agent**](https://nightopsai.dev/) | Autonomous infrastructure agents that detect & fix cluster issues |
-| ⚡ [**Dispatch**](https://dispatchai.dev/) | Dispatch is an AI-powered CLI tool that solves GitHub issues in batch — creating branches, implementing fixes, and opening pull requests while you sleep.|
-| 📦 [**Azure-MCP-Server**](https://github.com/nomadicmehul/Azure-MCP-Server) | Production-ready MCP server for Azure Cloud, Kubernetes (AKS), and Azure DevOps - 100% Read-Only |
+| 🤖 [**NightOps AI**](https://nightopsai.dev/) | Autonomous SRE agents that detect & fix cluster issues in real time |
+| ⚡ [**Dispatch**](https://dispatchai.dev/) | AI-powered CLI that solves GitHub issues in batch — branches, fixes, and PRs while you sleep |
+| 📦 [**Azure MCP Server**](https://github.com/nomadicmehul/Azure-MCP-Server) | Production-ready MCP server for Azure Cloud, Kubernetes (AKS), and Azure DevOps — 100% read-only |
+| 🧠 [**Hello GenAI**](https://github.com/nomadicmehul/Hello-GenAI) | Generative AI tutorials and hands-on labs for developers |
+| 📚 [**CloudCaptain**](https://github.com/nomadicmehul/CloudCaptain) | Comprehensive DevOps and cloud learning resources |
 
 ---
 
@@ -51,54 +67,59 @@ I'm a **Senior DevOps Engineer** based in Berlin with **500+ technical sessions*
 ![Azure](https://img.shields.io/badge/Microsoft_Azure-0078D4?style=for-the-badge&logo=microsoftazure&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-2CA5E0?style=for-the-badge&logo=docker&logoColor=white)
 ![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
+![Helm](https://img.shields.io/badge/Helm-0F1689?style=for-the-badge&logo=helm&logoColor=white)
+
+**Infrastructure as Code**
+
 ![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white)
 ![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=for-the-badge&logo=ansible&logoColor=white)
+![Pulumi](https://img.shields.io/badge/Pulumi-8A3391?style=for-the-badge&logo=pulumi&logoColor=white)
+
+**CI/CD & GitOps**
+
+![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=for-the-badge&logo=githubactions&logoColor=white)
+![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=for-the-badge&logo=jenkins&logoColor=white)
+![ArgoCD](https://img.shields.io/badge/Argo_CD-EF7B4D?style=for-the-badge&logo=argo&logoColor=white)
+![GitLab CI](https://img.shields.io/badge/GitLab_CI-FC6D26?style=for-the-badge&logo=gitlab&logoColor=white)
+
+**Observability**
+
+![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=prometheus&logoColor=white)
+![Grafana](https://img.shields.io/badge/Grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white)
+![Datadog](https://img.shields.io/badge/Datadog-632CA6?style=for-the-badge&logo=datadog&logoColor=white)
 
 **Dev & Automation**
 
-![Bash](https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
-![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=for-the-badge&logo=jenkins&logoColor=white)
+![Bash](https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 
-**🌱 Currently Learning**
+**AI / ML Ops**
 
-![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
-![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)
-![AI DevOps](https://img.shields.io/badge/AI_in_DevOps-FF6F00?style=for-the-badge&logo=google-gemini&logoColor=white)
+![Vertex AI](https://img.shields.io/badge/Vertex_AI-4285F4?style=for-the-badge&logo=google-cloud&logoColor=white)
+![MLflow](https://img.shields.io/badge/MLflow-0194E2?style=for-the-badge&logo=mlflow&logoColor=white)
+![AI Agents](https://img.shields.io/badge/AI_Agents-FF6F00?style=for-the-badge&logo=google-gemini&logoColor=white)
 
 ---
 
 ## 📊 GitHub Stats
 
 <div align="center">
-  <table>
-    <tr>
-      <td>
-        <img src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=nomadicmehul&theme=nord_dark" alt="Mehul's GitHub Stats" height="180" />
-      </td>
-      <td>
-        <img src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=nomadicmehul&theme=nord_dark" alt="Top Languages" height="180" />
-      </td>
-    </tr>
-    <tr>
-      <td colspan="2" align="center">
-        <img src="https://github-readme-streak-stats.herokuapp.com?user=nomadicmehul&theme=dark&hide_border=true&ring=bb2acf&fire=bb2acf&currStreakLabel=ffffff" alt="GitHub Streak" height="180" />
-      </td>
-    </tr>
-  </table>
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=nomadicmehul&theme=nord_dark" alt="GitHub Stats" height="180" />
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=nomadicmehul&theme=nord_dark" alt="Top Languages" height="180" />
+  <br/>
+  <img src="https://github-readme-streak-stats.herokuapp.com?user=nomadicmehul&theme=dark&hide_border=true&ring=bb2acf&fire=bb2acf&currStreakLabel=ffffff" alt="GitHub Streak" height="180" />
 </div>
-
----
 
 ---
 
 <div align="center">
 
-*Open to exciting DevOps, Platform Engineering, and Cloud Architecture opportunities.*
+### 💬 Let's Connect
 
-**Let's build something great together. 🚀**
+*Open to DevOps, Platform Engineering, and Cloud Architecture opportunities.*
 
-🌐 [nomadicmehul.dev](https://nomadicmehul.dev/)
+📅 [Book a Call](https://topmate.io/nomadicmehul) · 🌐 [nomadicmehul.dev](https://nomadicmehul.dev/) · 🔗 [All Links](https://bio.link/nomadicmehul)
 
 </div>

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,8 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 - 🐳 **Docker Captain** — one of ~150 globally recognized Docker experts
 - ☁️ **Google Developer Expert** — Google Cloud
 - 🛠️ **AWS Community Builder** — Cloud Architecture & DevOps
-- 🔐 **Auth0 Ambassador** — Auth0 by Okta
-- 🦊 **Mozilla Reps Council Member**
+- 🔐 **Ex Auth0 Ambassador** — Auth0 by Okta
+- 🦊 **Ex Mozilla Reps Council Member**
 - 🎙️ Podcast Host — [TACOS with Mehul](https://www.youtube.com/playlist?list=PL7m7kHJFCVjXKK9jeyWwroPYsvNUaPqCH)
 - 🌐 Founder — [CloudCaptain](https://github.com/nomadicmehul/CloudCaptain) & [Open Source Weekend](https://twitter.com/OSWeekend)
 - 🏙️ Community Organizer — [GDG Cloud Gandhinagar](https://gdg.community.dev/gdg-cloud-gandhinagar/) · [CNCF Cloud Native Gandhinagar](https://community.cncf.io/cloud-native-gandhinagar/) · [HashiCorp UG Gandhinagar](https://www.meetup.com/gandhinagar-hashicorp-user-group/)

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@
 
 ## 🚀 About Me
 
+<img align="right" alt="Mehul Patel" src="https://camo.githubusercontent.com/f1ba0d26a1c7cdabebe6aefb07535f0e723ebb9e39dadb010bbdb2839331fa61/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f386b6c4d426e726e64366d7273574d4c31302f67697068792e676966" width="280" />
+
 I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ technical sessions** delivered across **25+ countries**, impacting **50,000+ developers**. I specialize in cloud-native infrastructure, containerization, and AI-powered DevOps workflows.
 
 - 🐳 **Docker Captain** — one of ~150 globally recognized Docker experts

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 | 🤖 [**NightOps AI**](https://nightopsai.dev/) | Autonomous SRE agents that detect & fix cluster issues in real time |
 | ⚡ [**Dispatch**](https://dispatchai.dev/) | AI-powered CLI that solves GitHub issues in batch — branches, fixes, and PRs while you sleep |
 | 📦 [**Azure MCP Server**](https://github.com/nomadicmehul/Azure-MCP-Server) | Production-ready MCP server for Azure Cloud, Kubernetes (AKS), and Azure DevOps — 100% read-only |
-| 🧠 [**Hello GenAI**](https://github.com/nomadicmehul/Hello-GenAI) | Multi-language chatbot (Go, Python, Node.js, Rust) powered by local LLMs |
+| 🧠 [**Hello GenAI**](https://github.com/nomadicmehul/Hello-GenAI) | Multi-language chatbot (Go, Python, Node.js, Rust) powered by local LLMs using Docker Model Runner |
 | 📚 [**CloudCaptain**](https://github.com/nomadicmehul/CloudCaptain) | Comprehensive DevOps and cloud learning resources |
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,6 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 
 ![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
 ![Bash](https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
-![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 
 **AI / ML Ops**
@@ -100,6 +99,11 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 ![Vertex AI](https://img.shields.io/badge/Vertex_AI-4285F4?style=for-the-badge&logo=google-cloud&logoColor=white)
 ![MLflow](https://img.shields.io/badge/MLflow-0194E2?style=for-the-badge&logo=mlflow&logoColor=white)
 ![AI Agents](https://img.shields.io/badge/AI_Agents-FF6F00?style=for-the-badge&logo=google-gemini&logoColor=white)
+
+**🌱 Currently Learning**
+
+![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
+![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 | 🤖 [**NightOps AI**](https://nightopsai.dev/) | Autonomous SRE agents that detect & fix cluster issues in real time |
 | ⚡ [**Dispatch**](https://dispatchai.dev/) | AI-powered CLI that solves GitHub issues in batch — branches, fixes, and PRs while you sleep |
 | 📦 [**Azure MCP Server**](https://github.com/nomadicmehul/Azure-MCP-Server) | Production-ready MCP server for Azure Cloud, Kubernetes (AKS), and Azure DevOps — 100% read-only |
-| 🧠 [**Hello GenAI**](https://github.com/nomadicmehul/Hello-GenAI) | Generative AI tutorials and hands-on labs for developers |
+| 🧠 [**Hello GenAI**](https://github.com/nomadicmehul/Hello-GenAI) | Multi-language chatbot (Go, Python, Node.js, Rust) powered by local LLMs |
 | 📚 [**CloudCaptain**](https://github.com/nomadicmehul/CloudCaptain) | Comprehensive DevOps and cloud learning resources |
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -111,9 +111,7 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 ## 📊 GitHub Stats
 
 <div align="center">
-  <img src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=nomadicmehul&theme=nord_dark" alt="GitHub Stats" height="140" />
-  <img src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=nomadicmehul&theme=nord_dark" alt="Top Languages" height="140" />
-  <img src="https://github-readme-streak-stats.herokuapp.com?user=nomadicmehul&theme=dark&hide_border=true&ring=bb2acf&fire=bb2acf&currStreakLabel=ffffff" alt="GitHub Streak" height="140" />
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=nomadicmehul&theme=nord_dark" alt="GitHub Profile Details" width="720" />
 </div>
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 - 🔐 **Ex Auth0 Ambassador** — Auth0 by Okta
 - 🦊 **Ex Mozilla Reps Council Member**
 - 🎙️ Podcast Host — [TACOS with Mehul](https://www.youtube.com/playlist?list=PL7m7kHJFCVjXKK9jeyWwroPYsvNUaPqCH)
-- 🌐 Founder — [CloudCaptain](https://github.com/nomadicmehul/CloudCaptain) & [Open Source Weekend](https://twitter.com/OSWeekend)
+- 🌐 Founder — [CloudCaptain](https://cloudcaptain.io/) & [Open Source Weekend](https://twitter.com/OSWeekend)
 - 🏙️ Community Organizer — [Grafana and Friends Berlin](https://www.meetup.com/grafana-and-friends-berlin/)
 - 🏙️ Ex Community Organizer — [GDG Cloud Gandhinagar](https://gdg.community.dev/gdg-cloud-gandhinagar/) · [CNCF Cloud Native Gandhinagar](https://community.cncf.io/cloud-native-gandhinagar/) · [HashiCorp UG Gandhinagar](https://www.meetup.com/gandhinagar-hashicorp-user-group/)
 
@@ -55,7 +55,7 @@ I'm a **Senior DevOps Engineer** based in **Berlin, Germany** with **500+ techni
 | ⚡ [**Dispatch**](https://dispatchai.dev/) | AI-powered CLI that solves GitHub issues in batch — branches, fixes, and PRs while you sleep |
 | 📦 [**Azure MCP Server**](https://github.com/nomadicmehul/Azure-MCP-Server) | Production-ready MCP server for Azure Cloud, Kubernetes (AKS), and Azure DevOps — 100% read-only |
 | 🧠 [**Hello GenAI**](https://github.com/nomadicmehul/Hello-GenAI) | Multi-language chatbot (Go, Python, Node.js, Rust) powered by local LLMs using Docker Model Runner |
-| 📚 [**CloudCaptain**](https://github.com/nomadicmehul/CloudCaptain) | Comprehensive DevOps and cloud learning resources |
+| 📚 [**CloudCaptain**](https://cloudcaptain.io/) | Comprehensive DevOps and cloud learning resources |
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,6 @@
 [![Website](https://img.shields.io/badge/Website-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white)](https://nomadicmehul.dev/)
 
 ![Profile Views](https://komarev.com/ghpvc/?username=nomadicmehul&style=for-the-badge&color=blueviolet&label=PROFILE+VIEWS)
-![Website Visits](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhits.dwyl.com%2Fnomadicmehul%2Fnomadicmehul.dev.json&query=%24.count&label=WEBSITE+VISITS&style=for-the-badge&color=blueviolet)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Added missing roles (Auth0 Ambassador, Mozilla Reps Council Member)
- Added Community Impact section with speaking/mentoring stats
- Expanded tech stack into 6 categories (Cloud, IaC, CI/CD, Observability, Dev, AI/ML)
- Added Hello GenAI and CloudCaptain to featured projects
- Added profile views and website visit counters
- Added Instagram badge, Topmate booking link, and bio.link
- Updated tagline

## Test plan
- [x] Verify README renders correctly on GitHub profile page
- [x] Confirm visitor counter badges load properly
- [x] Check all project and social links work